### PR TITLE
Support pivot payload in custom model events

### DIFF
--- a/src/Traits/ExtendFireModelEventTrait.php
+++ b/src/Traits/ExtendFireModelEventTrait.php
@@ -28,14 +28,6 @@ trait ExtendFireModelEventTrait
             ? 'until'
             : 'dispatch';
 
-        $result = $this->filterModelEventResults(
-            $this->fireCustomModelEvent($event, $method)
-        );
-
-        if (false === $result) {
-            return false;
-        }
-
         $payload = [
             'model' => $this,
             'relation' => $relationName,
@@ -43,12 +35,42 @@ trait ExtendFireModelEventTrait
             'pivotIdsAttributes' => $idsAttributes,
             0 => $this,
         ];
+
+        $result = $this->filterModelEventResults(
+            $this->fireCustomModelEvent($event, $method, $payload)
+        );
+
+        if (false === $result) {
+            return false;
+        }
+
         $result = $result
             ?: static::$dispatcher
                 ->{$method}("eloquent.{$event}: " . static::class, $payload);
         $this->broadcastPivotEvent($event, $payload);
 
         return $result;
+    }
+
+    /**
+     * Fire a custom model event for the given event.
+     *
+     * @param  string  $event
+     * @param  string  $method
+     *
+     * @return mixed|null
+     */
+    protected function fireCustomModelEvent($event, $method, $payload = [])
+    {
+        if (! isset($this->dispatchesEvents[$event])) {
+            return;
+        }
+
+        $result = static::$dispatcher->$method(new $this->dispatchesEvents[$event]($this, $payload));
+
+        if (! is_null($result)) {
+            return $result;
+        }
     }
 
     protected function broadcastPivotEvent(string $event, array $payload): void


### PR DESCRIPTION


This feature makes the following use case with custom model event classes possible.

```php
class MyModel extends Model
{
    use PivotEventTrait;

    /**
     * @var array<string, class-string>
     */
    protected $dispatchesEvents = [
        'pivotSynced' => MyEvent::class,
    ];
}
```
```php
readonly class MyEvent
{
    /**
     * @param array{
     *     model: Model,
     *     relation: string,
     *     pivotIds: array<array-key, int|string>,
     *     pivotIdsAttributes: array<int|string, array<string, mixed>>,
     * } $payload
     */
    public function __construct(
        public MyModel $model,
        public array $payload,
    ) {
    }
}
```
```php
readonly class MyListener
{
    public function __invoke(MyEvent $event): void
    {
         // $event->model
         // $event->payload
    }
}
```