### PR TITLE
feat: ✨ suppress pivotSynced and pivotDetached events when no changes occur.

### DIFF
--- a/src/Traits/FiresPivotEventsTrait.php
+++ b/src/Traits/FiresPivotEventsTrait.php
@@ -21,7 +21,9 @@ trait FiresPivotEventsTrait
 
         $parentResult = parent::sync($ids, $detaching);
 
-        $this->parent->fireModelEvent('pivotSynced', false, $this->getRelationName(), $parentResult);
+        if (array_filter($parentResult)) {
+            $this->parent->fireModelEvent('pivotSynced', false, $this->getRelationName(), $parentResult);
+        }
 
         return $parentResult;
     }
@@ -62,7 +64,10 @@ trait FiresPivotEventsTrait
 
         $this->parent->fireModelEvent('pivotDetaching', true, $this->getRelationName(), $idsOnly);
         $parentResult = parent::detach($ids, $touch);
-        $this->parent->fireModelEvent('pivotDetached', false, $this->getRelationName(), $idsOnly);
+
+        if ($parentResult) {
+            $this->parent->fireModelEvent('pivotDetached', false, $this->getRelationName(), $idsOnly);
+        }
 
         return $parentResult;
     }

--- a/tests/DispatchesEventsTest.php
+++ b/tests/DispatchesEventsTest.php
@@ -339,7 +339,7 @@ class DispatchesEventsTest extends TestCase
         $this->assertSame('roles', $synced[0]->payload['relation']);
     }
 
-    public function test_sync_to_same_state_fires_only_synced_custom_event()
+    public function test_sync_to_same_state_does_not_fire_synced_custom_event()
     {
         $user = UserWithFullPayloadEvents::find(1);
         $user->roles()->attach([1]);
@@ -355,7 +355,7 @@ class DispatchesEventsTest extends TestCase
 
         $this->assertCount(0, $attached, 'No attach when syncing to same state');
         $this->assertCount(0, $detached, 'No detach when syncing to same state');
-        $this->assertCount(1, $synced, 'pivotSynced should still fire');
+        $this->assertCount(0, $synced, 'pivotSynced should not fire when nothing changed');
     }
 
     public function test_sync_empty_array_fires_detach_and_synced_custom_events()

--- a/tests/PivotEventTraitTest.php
+++ b/tests/PivotEventTraitTest.php
@@ -591,12 +591,11 @@ class PivotEventTraitTest extends TestCase
         $user->roles()->attach([1]);
 
         $this->startListening();
-        // Sync to same state — no changes, only syncing/synced
+        // Sync to same state — no changes, only syncing fires (synced suppressed)
         $user->roles()->sync([1]);
 
         $this->check_events([
             'eloquent.pivotSyncing: '.User::class,
-            'eloquent.pivotSynced: '.User::class,
         ]);
     }
 
@@ -616,6 +615,89 @@ class PivotEventTraitTest extends TestCase
             'eloquent.pivotSynced: '.User::class,
         ]);
         $this->check_database(2, 123);
+    }
+
+    // --- conditional event suppression tests ---
+
+    public function test_sync_no_changes_does_not_fire_synced()
+    {
+        $this->startListening();
+        $user = User::find(1);
+        $user->roles()->attach([1, 2]);
+
+        $this->startListening();
+        $user->roles()->sync([1, 2]);
+
+        $this->check_events([
+            'eloquent.pivotSyncing: '.User::class,
+        ]);
+    }
+
+    public function test_sync_with_changes_fires_synced()
+    {
+        $this->startListening();
+        $user = User::find(1);
+        $user->roles()->attach([1]);
+
+        $this->startListening();
+        $user->roles()->sync([2, 3]);
+
+        $this->check_events([
+            'eloquent.pivotSyncing: '.User::class,
+            'eloquent.pivotDetaching: '.User::class,
+            'eloquent.pivotDetached: '.User::class,
+            'eloquent.pivotAttaching: '.User::class,
+            'eloquent.pivotAttached: '.User::class,
+            'eloquent.pivotAttaching: '.User::class,
+            'eloquent.pivotAttached: '.User::class,
+            'eloquent.pivotSynced: '.User::class,
+        ]);
+    }
+
+    public function test_detach_non_existent_id_does_not_fire_detached()
+    {
+        $this->startListening();
+        $user = User::find(1);
+        $user->roles()->attach([1]);
+
+        $this->startListening();
+        $result = $user->roles()->detach([999]);
+
+        $this->assertEquals(0, $result);
+        $this->check_events([
+            'eloquent.pivotDetaching: '.User::class,
+        ]);
+    }
+
+    public function test_detach_existing_id_fires_detached()
+    {
+        $this->startListening();
+        $user = User::find(1);
+        $user->roles()->attach([1, 2]);
+
+        $this->startListening();
+        $result = $user->roles()->detach([1]);
+
+        $this->assertEquals(1, $result);
+        $this->check_events([
+            'eloquent.pivotDetaching: '.User::class,
+            'eloquent.pivotDetached: '.User::class,
+        ]);
+    }
+
+    public function test_polymorphic_detach_non_existent_does_not_fire_detached()
+    {
+        $this->startListening();
+        $post = Post::find(1);
+        $post->tags()->attach([1]);
+
+        $this->startListening();
+        $result = $post->tags()->detach([999]);
+
+        $this->assertEquals(0, $result);
+        $this->check_events([
+            'eloquent.pivotDetaching: '.Post::class,
+        ]);
     }
 
     private function check_events($events)


### PR DESCRIPTION
- Only fire `pivotSynced` event if sync operation results in changes.
- Only fire `pivotDetached` event if detach operation actually detaches records.
- Update tests to assert that events are not fired when no changes occur.
- Add new tests for conditional event firing on sync and detach operations.